### PR TITLE
Fix: Node12 Buffer Update

### DIFF
--- a/index.js
+++ b/index.js
@@ -121,12 +121,12 @@ instance.prototype.init_tcp = function() {
 		self.socket.on("iac", function(type, info) {
 			// tell remote we WONT do anything we're asked to DO
 			if (type == 'DO') {
-				socket.write(new Buffer([ 255, 252, info ]));
+				socket.write(Buffer.from([ 255, 252, info ]));
 			}
 
 			// tell the remote DONT do whatever they WILL offer
 			if (type == 'WILL') {
-				socket.write(new Buffer([ 255, 254, info ]));
+				socket.write(Buffer.from([ 255, 254, info ]));
 			}
 		});
 	}
@@ -203,7 +203,7 @@ instance.prototype.action = function(action) {
 	if (cmd !== undefined) {
 
 		if (self.socket !== undefined && self.socket.connected) {
-			console.log(new Buffer(cmd));
+			console.log(Buffer.from(cmd));
 			self.socket.write(cmd);
 		} else {
 			debug('Socket not connected :(');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "optoma-z28s",
-	"version": "1.0.1",
+	"version": "1.0.2",
 	"api_version": "1.0.0",
 	"keywords": [
 		"Projector"


### PR DESCRIPTION
Updated uses of the deprecated `new Buffer()` to the Node12 compliant functions `Buffer.from()` and `Buffer.alloc()`.

Changes made following the guidelines of Variant 1 of the NodeJS Buffer constructor deprecation guide  https://nodejs.org/en/docs/guides/buffer-constructor-deprecation/